### PR TITLE
Actually checkout branch in tag-pipeline.yml

### DIFF
--- a/.github/workflows/tag-pipeline.yml
+++ b/.github/workflows/tag-pipeline.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Checking out branch ${{ github.ref }}"
+      - name: Checkout branch
+        uses: actions/checkout@v2
       - name: Set version
         id: version
         run: |


### PR DESCRIPTION
## Description

`.github/workflows/tag-pipeline.yml` was missing the actual branch checkout step.

## Proposed Changes

- Actually checkout the branch

## Checklist

- [ ] ~`go fmt`~
- [ ] ~`go mod tidy && go mod vendor`~
- [ ] ~Relevant tests added~
- [ ] ~Relevant documentation added~
