### PR TITLE
Include tag param in create tag step

### DIFF
--- a/.github/workflows/tag-pipeline.yml
+++ b/.github/workflows/tag-pipeline.yml
@@ -17,12 +17,14 @@ jobs:
       - name: Set version
         id: version
         run: |
+          echo "Tag to be created --> $(make version)"
           echo "::set-output name=value::$(make version)"
       - name: Create tag
         uses: simpleactions/create-tag@v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           message: ${{ github.ref }} merged and created ${{ steps.version.outputs.value }}
+          tag: ${{ steps.version.outputs.value }}
       - name: Show tag
         run: |
           echo "Created version tag ${{ steps.tag.outputs.ref }}"


### PR DESCRIPTION
## Description

The `tag` parameter was missing from the `Create tag` step.

## Proposed Changes

- Add `tag` parameter

## Checklist

- [ ] ~`go fmt`~
- [ ] ~`go mod tidy && go mod vendor`~
- [ ] ~Relevant tests added~
- [ ] ~Relevant documentation added~
